### PR TITLE
Minor formatting updates to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,16 +29,17 @@ UDR must be on the client and server machines that data will be transferred betw
     udr [udr options] rsync [rsync options] src dest
 
 ### UDR options:
-[-a starting port number] default is 9000
-[-b ending port number] default is 9100
-[-n aes-128 | aes-192 | aes-256 | bf | des-ede3] turns on encryption, if crypto is not specified aes-128 is the default
-[-p path] local path for the .udr_key file used for encryption, default is the current directory
-[-c remote udr location] by default udr assumes that udr is in your path on the remote system, here you can specify the location explicitly
-[-o server port] port to access a UDR server, default is 9000
-[-v] verbose mode, typically for debugging purposes
-[--version] print out the version
-[-d timeout] specify duration in seconds in which to kill remaining threads if no data is transfered after connected, default is 15s
-[-i ip] specify the interface by ip that the remote process will bind to
+
+- `[-a starting port number]` default is 9000
+- `[-b ending port number]` default is 9100
+- `[-n aes-128 | aes-192 | aes-256 | bf | des-ede3]` turns on encryption, if crypto is not specified aes-128 is the default
+- `[-p path]` local path for the .udr_key file used for encryption, default is the current directory
+- `[-c remote udr location]` by default udr assumes that udr is in your path on the remote system, here you can specify the location explicitly
+- `[-o server port]` port to access a UDR server, default is 9000
+- `[-v]` verbose mode, typically for debugging purposes
+- `[--version]` print out the version
+- `[-d timeout]` specify duration in seconds in which to kill remaining threads if no data is transfered after connected, default is 15s
+- `[-i ip]` specify the interface by ip that the remote process will bind to
 
 The rsync [rsync options] should take any of the standard rsync options, except the -e/--rsh flag which how UDR interfaces with rsync.
 
@@ -59,9 +60,9 @@ The UDR server allows UDR transfers for users without accounts, similar to rsync
     python udrserver.py [-v] [-s] [-c configfile] start|stop|restart|foreground
 
 ### UDR server options:
-[-c config file] specify the location of the config file, default is /etc/udrd.conf
-[-s] silent mode, don't print message on start|stop|restart
-[-v] verbose mode, mainly for debugging purposes
+- `[-c config file]` specify the location of the config file, default is /etc/udrd.conf
+- `[-s]` silent mode, don't print message on start|stop|restart
+- `[-v]` verbose mode, mainly for debugging purposes
 
 ### UDR server configuration:
 The UDR server requires a configuration file, by default it looks for /etc/udrd.conf. The format of the file is a list of parameter of the format 'name = value'. An example config file is provided, the available parameters are:
@@ -72,20 +73,20 @@ The UDR server requires a configuration file, by default it looks for /etc/udrd.
 - end port: last UDP port to begin UDR connections on, default is 9100
 - log file: log file for UDR, default is <current working dir>/udr.log
 - log level: level of logging used, based on the python logging module, default is INFO
-- pid file: pid file used for daemon, default is /var/run/udrd.pid
+- pid file: pid file used for daemon, default is `/var/run/udrd.pid`
 - udr: path to udr command, default is udr
 - rsyncd conf: rsyncd.conf file to use for the rsync part of the configuration
 - uid: user name or uid that the server should run as when started as root, default is nobody when run as root
 - gid: group name or gid that the server should run as when started as root, default is nogroup when run as root
 - specify ip: IP address for udr receiver to bind to, default is any connected interface
 
-Most standard rsyncd.conf options should work like normal. Known exceptions are:
+Most standard `rsyncd.conf` options should work like normal. Known exceptions are:
 
 #### Max Connections
-The max connections option does not work, but the number of connections can be limited by the range of start and end port in the udrd.conf file because one connection requires one port. For example, if you only want 50 connections, set the start port to 9000 and the end port to 9050. If the max connections option is set, the rsync processes will try to write to the lock file, which they often do not have permission to and will return the error "@ERROR: failed to open lock file". You can set the lock file location in rsyncd.conf or remove the max connections option.
+The max connections option does not work, but the number of connections can be limited by the range of start and end port in the udrd.conf file because one connection requires one port. For example, if you only want 50 connections, set the start port to 9000 and the end port to 9050. If the max connections option is set, the rsync processes will try to write to the lock file, which they often do not have permission to and will return the error "@ERROR: failed to open lock file". You can set the lock file location in `rsyncd.conf` or remove the max connections option.
 
 #### UID/GID and chroot
-It is not recommended to run UDR server as root. However, then the rsync use chroot option will not be available. If chroot is desired, the uid/gid options in udrd.conf must be explicitly set to root. UDR will then parse and use the global uid/gid settings in rsyncd.conf for spawned subprocesses. However, it does not currently support different uid/gid for each module.
+It is not recommended to run UDR server as root. However, then the rsync use chroot option will not be available. If chroot is desired, the uid/gid options in udrd.conf must be explicitly set to root. UDR will then parse and use the global uid/gid settings in `rsyncd.conf` for spawned subprocesses. However, it does not currently support different uid/gid for each module.
 
 #### WARNING: UDR server has only be tested in read only mode, it is not recommended to enable write access.
 


### PR DESCRIPTION
Command options did not have line breaks -> formatted as a single paragraph, instead of multi-line, as intended.