### PR TITLE
Update to new SSL API & some memory fixes

### DIFF
--- a/src/crypto.h
+++ b/src/crypto.h
@@ -47,7 +47,7 @@ class crypto
     int hex_passphrase_size;
 
     // EVP stuff
-    EVP_CIPHER_CTX ctx;
+    EVP_CIPHER_CTX *ctx;
 
     public:
 
@@ -106,20 +106,18 @@ class crypto
 
         direction = direc;
         // EVP stuff
-        EVP_CIPHER_CTX_init(&ctx);
+        ctx = EVP_CIPHER_CTX_new();
 
-        if (!EVP_CipherInit_ex(&ctx, cipher, NULL, password, ivec, direc)) {
+        if (!EVP_CipherInit_ex(ctx, cipher, NULL, password, ivec, direc)) {
             fprintf(stderr, "error setting encryption scheme\n");
             exit(EXIT_FAILURE);
         }
     }
 
-//    ~crypto()
-//    {
-//        // i guess thread issues break this but it needs to be done
-//        //TODO: find out why this is bad and breaks things
-//        EVP_CIPHER_CTX_cleanup(&ctx);
-//    }
+    ~crypto()
+    {
+        EVP_CIPHER_CTX_free(ctx);
+    }
 
     // Returns how much has been encrypted and will call encrypt final when
     // given len of 0
@@ -128,14 +126,14 @@ class crypto
         int evp_outlen;
 
         if (len == 0) {
-            if (!EVP_CipherFinal_ex(&ctx, (unsigned char *)out, &evp_outlen)) {
+            if (!EVP_CipherFinal_ex(ctx, (unsigned char *)out, &evp_outlen)) {
                 fprintf(stderr, "encryption error\n");
                 exit(EXIT_FAILURE);
             }
             return evp_outlen;
         }
 
-        if(!EVP_CipherUpdate(&ctx, (unsigned char *)out, &evp_outlen, (unsigned char *)in, len))
+        if(!EVP_CipherUpdate(ctx, (unsigned char *)out, &evp_outlen, (unsigned char *)in, len))
         {
             fprintf(stderr, "encryption error\n");
             exit(EXIT_FAILURE);

--- a/src/udr.cpp
+++ b/src/udr.cpp
@@ -177,7 +177,7 @@ int main(int argc, char* argv[]) {
             fprintf(stderr, "%s udr_cmd %s\n", curr_options.which_process, udr_cmd);
         }
 
-        int line_size = NI_MAXSERV + PASSPHRASE_SIZE * 2 + 1;
+        int line_size = NI_MAXSERV + PASSPHRASE_SIZE * 2 + 2;
         char * line = (char*) malloc(line_size);
         line[0] = '\0';
 
@@ -235,7 +235,8 @@ int main(int argc, char* argv[]) {
 
             fork_execvp(curr_options.ssh_program, ssh_argv, &sshparent_to_child, &sshchild_to_parent);
 
-            nbytes = read(sshchild_to_parent, line, line_size);
+            nbytes = read(sshchild_to_parent, line, line_size-1);
+            line[nbytes] = '\0';
 
             if (curr_options.verbose) {
                 fprintf(stderr, "%s Received string: %s\n", curr_options.which_process, line);

--- a/src/udr.cpp
+++ b/src/udr.cpp
@@ -123,8 +123,8 @@ int main(int argc, char* argv[]) {
         string sep = " ";
         char** rsync_args = &argv[rsync_arg_idx];
         int rsync_argc = argc - rsync_arg_idx;
-        char hex_pp[HEX_PASSPHRASE_SIZE];
-        unsigned char passphrase[PASSPHRASE_SIZE];
+        char hex_pp[HEX_PASSPHRASE_SIZE+1];
+        unsigned char passphrase[PASSPHRASE_SIZE+1];
 
         if (curr_options.encryption) {
             if (curr_options.verbose)
@@ -134,15 +134,17 @@ int main(int argc, char* argv[]) {
                 fprintf(stderr, "UDR ERROR: could not read from key_file %s\n", curr_options.key_filename);
                 exit(EXIT_FAILURE);
             }
-            fscanf(key_file, "%s", hex_pp);
+            fgets(hex_pp, HEX_PASSPHRASE_SIZE+1, key_file);
             fclose(key_file);
             remove(curr_options.key_filename);
 
-            for (unsigned int i = 0; i < strlen(hex_pp); i = i + 2) {
+            unsigned int i;
+            for (i = 0; i < strlen(hex_pp); i = i + 2) {
                 unsigned int c;
                 sscanf(&hex_pp[i], "%02x", &c);
                 passphrase[i / 2] = (unsigned char) c;
             }
+            passphrase[i / 2] = '\0';
         }
 
         snprintf(curr_options.host, PATH_MAX, "%s", argv[rsync_arg_idx - 1]);

--- a/src/udr_options.cpp
+++ b/src/udr_options.cpp
@@ -68,7 +68,7 @@ void set_default_udr_options(UDR_Options * options) {
     options->version[0] = '\0';
     options->server_dir[0] = '\0';
     options->server_config[0] = '\0';
-    snprintf(options->server_port, PATH_MAX, "%s", "9000");
+    snprintf(options->server_port, NI_MAXSERV, "%s", "9000");
 
     options->specify_ip = NULL;
 

--- a/src/udr_threads.cpp
+++ b/src/udr_threads.cpp
@@ -451,8 +451,9 @@ int run_receiver(UDR_Options * udr_options) {
 	return 0;
     }
 
-    unsigned char rand_pp[PASSPHRASE_SIZE];
+    unsigned char rand_pp[PASSPHRASE_SIZE+1];
     int success = RAND_bytes((unsigned char *) rand_pp, PASSPHRASE_SIZE);
+    rand_pp[PASSPHRASE_SIZE] = '\0';
 
     //stdout port number and password -- to send back to the client
     printf("%s ", receiver_port);


### PR DESCRIPTION
Hi,

this probably should be split into two, but here goes anyway:
 * The first commit updates the API to openssl > 1.0.2; I don't have any machine with old openssl around to test compat (not sure if the `EVP_CIPHER_CTX_new` function was available before or not); it might need some `#if` macros if you want compat, I can do it eventually but it won't be a priority;
 * the other two commits fix some wild memory accesses reported by asan (compile & link with `-fsanitize=address`); this shouldn't break anything for anyone and might help with some random bugs, not null-terminating the encryption key in particular lead to difficult-to-debug rsync protocol mismatch errors.